### PR TITLE
More utilities

### DIFF
--- a/src/invetica/test/spec.clj
+++ b/src/invetica/test/spec.clj
@@ -28,5 +28,4 @@
   [ns]
   (doseq [result (stest/check (stest/enumerate-namespace ns))]
     (is (-> result :failure nil?)
-        (with-out-str
-          (pprint (stest/abbrev-result result))))))
+        (with-out-str (pprint result)))))

--- a/src/invetica/test/spec.clj
+++ b/src/invetica/test/spec.clj
@@ -7,7 +7,26 @@
    ;;
    ;; See https://github.com/clojure-emacs/cider/issues/1841.
    [clojure.test.check]
-   [clojure.test :refer [is]]))
+   [clojure.test :as t :refer [is]]
+   [clojure.spec.alpha :as s]))
+
+;; -----------------------------------------------------------------------------
+;; Fixtures
+
+(defn check-asserts
+  "Convenience function compatible with `clojure.test/use-fixtures`, that will
+  enable checking of clojure.spec assertions.
+
+  E.g.
+
+      (clojure.test/use-fixtures :once test.spec/check-asserts)"
+  [f]
+  (let [before (s/check-asserts?)]
+    (try
+      (s/check-asserts true)
+      (f)
+      (finally
+        (s/check-asserts before)))))
 
 (defn instrument
   "Convenience function compatible with `clojure.test/use-fixtures`, that will
@@ -22,6 +41,11 @@
     (f)
     (finally
       (stest/unstrument))))
+
+(def once-fixtures
+  "Spec-related fixtures compatible with `clojure.test/use-fixtures`. Enables
+  checking of assertions and instrumentation of functions."
+  (t/join-fixtures [check-asserts instrument]))
 
 (defn is-well-specified
   "Checks all of the vars in namespace `ns`, and pretty prints any failures."

--- a/test/invetica/test/spec_test.clj
+++ b/test/invetica/test/spec_test.clj
@@ -1,0 +1,19 @@
+(ns invetica.test.spec-test
+  (:require
+   [clojure.spec.alpha :as s]
+   [clojure.test :refer :all]
+   [invetica.test.spec :as sut]))
+
+(use-fixtures :once sut/once-fixtures)
+
+(s/def ::int integer?)
+(s/def ::str string?)
+
+(s/def ::map
+  (s/keys :req [::int ::str]))
+
+(deftest t-specs
+  (is (well-specified? 'invetica.test.spec)))
+
+(deftest t-assert-expressions
+  (is (conforming? ::map {::int 11 ::str "This is a string"})))


### PR DESCRIPTION
Stop abbreviating failed test/checks because you won't see what's actually gone wrong using `abbrev-result`.

Add some custom clojure.test assertions that reduce the amount of boilerplate needed to make spec-based assertions.

Add another `:once` fixture that can augment the behaviour of clojure.spec during test runs.